### PR TITLE
API Remove concrete CMS dependency in favour of framework as a minimum requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     - php: 7.0
       env: DB=MYSQL PHPUNIT_TEST=1
     - php: 7.1
-      env: DB=MYSQL PHPUNIT_COVERAGE_TEST=1
+      env: DB=MYSQL PHPUNIT_COVERAGE_TEST=1 CMS=1
     - php: 7.2
       env: DB=MYSQL PHPUNIT_TEST=1
 
@@ -22,12 +22,14 @@ before_script:
 
   # Install composer dependencies
   - composer validate
-  - composer require --no-update silverstripe/recipe-cms 1.0.x-dev
+  - if [[ $CMS ]]; then composer require --no-update silverstripe/recipe-cms 1.0.x-dev; fi
+  - if [[ ! $CMS ]]; then composer require --no-update silverstripe/recipe-core 1.0.x-dev; fi
   - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
 script:
   - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit; fi
-  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=coverage.xml; fi
+  # Coverage runs also run with the CMS
+  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=coverage.xml --bootstrap=vendor/silverstripe/cms/tests/bootstrap.php; fi
   - if [[ $PHPCS_TEST ]]; then vendor/bin/phpcs code/ tests/ *.php; fi
 
 after_success:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2017, SilverStripe Limited
+Copyright (c) 2018, SilverStripe Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -18,6 +18,11 @@ SilverStripe\Security\Member:
   extensions:
     - SilverStripe\Auditor\AuditHook
 
+---
+Name: auditorcms
+Only:
+  moduleexists: silverstripe/cms
+---
 SilverStripe\CMS\Model\SiteTree:
   extensions:
     - SilverStripe\Auditor\AuditHook

--- a/code/AuditHook.php
+++ b/code/AuditHook.php
@@ -2,10 +2,10 @@
 
 namespace SilverStripe\Auditor;
 
-use SilverStripe\CMS\Model\SiteTreeExtension;
 use SilverStripe\Control\Email\Email;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\Connect\Database;
+use SilverStripe\ORM\DataExtension;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DataObjectSchema;
 use SilverStripe\ORM\DB;
@@ -17,7 +17,7 @@ use SilverStripe\Security\Security;
 /**
  * Provides logging hooks that are inserted into Framework objects.
  */
-class AuditHook extends SiteTreeExtension
+class AuditHook extends DataExtension
 {
     protected function getAuditLogger()
     {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "keywords": ["silverstripe", "audit"],
     "license": "BSD-3-Clause",
     "require": {
-        "silverstripe/cms": "^4.0",
+        "silverstripe/framework": "^4.0",
         "monolog/monolog": "~1.11",
         "psr/log": "~1.0"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="vendor/silverstripe/cms/tests/bootstrap.php" colors="true">
+<phpunit bootstrap="vendor/silverstripe/framework/tests/bootstrap.php" colors="true">
     <testsuite name="Default">
         <directory>tests/</directory>
     </testsuite>

--- a/tests/AuditHookTest.php
+++ b/tests/AuditHookTest.php
@@ -165,6 +165,10 @@ class AuditHookTest extends FunctionalTest
 
     public function testPublishPage()
     {
+        if (!class_exists(Page::class)) {
+            $this->markTestSkipped('This test requires the CMS module installed.');
+        }
+
         $this->logInWithPermission('ADMIN');
 
         $page = new Page();
@@ -181,6 +185,10 @@ class AuditHookTest extends FunctionalTest
 
     public function testUnpublishPage()
     {
+        if (!class_exists(Page::class)) {
+            $this->markTestSkipped('This test requires the CMS module installed.');
+        }
+
         $this->logInWithPermission('ADMIN');
 
         $page = new Page();
@@ -198,6 +206,10 @@ class AuditHookTest extends FunctionalTest
 
     public function testDuplicatePage()
     {
+        if (!class_exists(Page::class)) {
+            $this->markTestSkipped('This test requires the CMS module installed.');
+        }
+
         $this->logInWithPermission('ADMIN');
 
         $page = new Page();
@@ -214,6 +226,10 @@ class AuditHookTest extends FunctionalTest
 
     public function testRevertToLive()
     {
+        if (!class_exists(Page::class)) {
+            $this->markTestSkipped('This test requires the CMS module installed.');
+        }
+
         $this->logInWithPermission('ADMIN');
 
         $page = new Page();
@@ -234,6 +250,10 @@ class AuditHookTest extends FunctionalTest
 
     public function testDelete()
     {
+        if (!class_exists(Page::class)) {
+            $this->markTestSkipped('This test requires the CMS module installed.');
+        }
+
         $this->logInWithPermission('ADMIN');
 
         $page = new Page();
@@ -252,6 +272,10 @@ class AuditHookTest extends FunctionalTest
 
     public function testRestoreToStage()
     {
+        if (!class_exists(Page::class)) {
+            $this->markTestSkipped('This test requires the CMS module installed.');
+        }
+
         $this->logInWithPermission('ADMIN');
 
         $page = new Page();


### PR DESCRIPTION
Switches to ensure that the module can be used with framework only