### PR TITLE
NEW Use tractorcow/silverstripe-proxy-db to handle database manipulations via middleware proxy

### DIFF
--- a/_config/dbproxy.yml
+++ b/_config/dbproxy.yml
@@ -1,0 +1,6 @@
+---
+Name: auditordbproxy
+---
+TractorCow\SilverStripeProxyDB\ProxyDBFactory:
+  extensions:
+    - SilverStripe\Auditor\Extensions\ProxyDBExtension

--- a/code/AuditHook.php
+++ b/code/AuditHook.php
@@ -33,6 +33,8 @@ class AuditHook extends DataExtension
      * This will bind a new class dynamically so we can hook into manipulation
      * and capture it. It creates a new PHP file in the temp folder, then
      * loads it and sets it as the active DB class.
+     *
+     * @deprecated 2.1...3.0 Please use ProxyDBExtension with the tractorcow/silverstripe-proxy-db module instead
      */
     public static function bind_manipulation_capture()
     {
@@ -386,9 +388,12 @@ class AuditHook extends DataExtension
         $this->getAuditLogger()->info(sprintf('Failed login attempt using email "%s"', $login));
     }
 
+    /**
+     * @deprecated 2.1...3.0 Use tractorcow/silverstripe-proxy-db instead
+     */
     public function onBeforeInit()
     {
-        self::bind_manipulation_capture();
+        // no-op
     }
 
     /**

--- a/code/Extensions/ProxyDBExtension.php
+++ b/code/Extensions/ProxyDBExtension.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace SilverStripe\Auditor\Extensions;
+
+use SilverStripe\Auditor\AuditHook;
+use SilverStripe\Core\Extension;
+use TractorCow\ClassProxy\Generators\ProxyGenerator;
+
+class ProxyDBExtension extends Extension
+{
+    /**
+     * Bind a proxy callback into the Database::manipulate method to allow us to track database activity
+     * for the {@link AuditHook} class
+     *
+     * @param ProxyGenerator $proxy
+     */
+    public function updateProxy(ProxyGenerator &$proxy)
+    {
+        $proxy = $proxy->addMethod('manipulate', function ($args, $next) {
+            $manipulation = $args[0];
+            AuditHook::handle_manipulation($manipulation);
+            return $next(...$args);
+        });
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "require-dev": {
         "phpunit/phpunit": "^5.7",
         "squizlabs/php_codesniffer": "^3.0",
-        "silverstripe/versioned": "^1.0"
+        "silverstripe/versioned": "^1.0",
+        "tractorcow/silverstripe-proxy-db": "~0.1"
     },
     "autoload": {
         "psr-4": {

--- a/tests/AuditHookTest.php
+++ b/tests/AuditHookTest.php
@@ -25,10 +25,6 @@ class AuditHookTest extends FunctionalTest
         // Phase singleton out, so the message log is purged.
         Injector::inst()->unregisterNamedObject('AuditLogger');
         Injector::inst()->registerService($this->writer, 'AuditLogger');
-
-        // ensure the manipulations are being captured, normally called in {@link AuditLogger::onBeforeInit()}
-        // but tests will reset this during setting up, so we need to set it back again.
-        AuditHook::bind_manipulation_capture();
     }
 
     public function testLoggingIn()


### PR DESCRIPTION
Also deprecates the old methods because we've already stabilised this module for 2.0.

Resolves #16 and resolves https://github.com/tractorcow/silverstripe-proxy-db/issues/2