### PR TITLE
FIX don't error on first write

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,13 @@ env:
 matrix:
   include:
     - php: 5.6
-      env: DB=MYSQL PHPCS_TEST=1 PHPUNIT_TEST=1
+      env: DB=MYSQL PHPCS_TEST=1 PHPUNIT_TEST=1 RECIPE_VERSION=1.0.x-dev
     - php: 7.0
-      env: DB=MYSQL PHPUNIT_TEST=1
+      env: DB=MYSQL PHPUNIT_TEST=1 RECIPE_VERSION=1.1.x-dev
     - php: 7.1
-      env: DB=MYSQL PHPUNIT_COVERAGE_TEST=1 CMS=1
+      env: DB=MYSQL PHPUNIT_COVERAGE_TEST=1 CMS=1 RECIPE_VERSION=1.1.x-dev CMS=1
     - php: 7.2
-      env: DB=MYSQL PHPUNIT_TEST=1
+      env: DB=MYSQL PHPUNIT_TEST=1 RECIPE_VERSION=1.x-dev
 
 before_script:
   # Init PHP

--- a/code/AuditHook.php
+++ b/code/AuditHook.php
@@ -205,8 +205,12 @@ class AuditHook extends DataExtension
             return false;
         }
 
+        // If there is no $original, this means the owner has not been published before.
+        // ChangeSetItem::publish will call Versioned::publishSingle
+        // which in turn checks the *_Live table, or sets $original to `null`.
+
         $effectiveViewerGroups = '';
-        if ($this->owner->CanViewType === 'OnlyTheseUsers') {
+        if ($original && $this->owner->CanViewType === 'OnlyTheseUsers') {
             $effectiveViewerGroups = implode(
                 ', ',
                 array_values($original->ViewerGroups()->map('ID', 'Title')->toArray())
@@ -217,7 +221,11 @@ class AuditHook extends DataExtension
         }
 
         $effectiveEditorGroups = '';
-        if ($this->owner->CanEditType === 'OnlyTheseUsers' && $original->EditorGroups()->exists()) {
+        if (
+            $original &&
+            $this->owner->CanEditType === 'OnlyTheseUsers' &&
+            $original->EditorGroups()->exists()
+        ) {
             $groups = [];
             foreach ($original->EditorGroups() as $group) {
                 $groups[$group->ID] = $group->Title;


### PR DESCRIPTION
In SilverStripe 4 the interface has changed for onAfterWrite extension
hooks, and the 'original' version is only supplied if the (Page) object
has previously been published. This means that it's possible for the
parameter to be `null`, which caused errors when attempting to
dereference assumed methods on it.