### PR TITLE
AuditorHook breaks when faced with UnsavedRelationList.

### DIFF
--- a/code/AuditHook.php
+++ b/code/AuditHook.php
@@ -92,20 +92,20 @@ class AuditHook extends \SiteTreeExtension
                 if ($table == 'Group') {
                     $extendedText = sprintf(
                         'Effective permissions: %s',
-                        implode(array_values($data->Permissions()->map('ID', 'Code')->toArray()), ', ')
+                        implode($data->Permissions()->column('Code'), ', ')
                     );
                 }
                 if ($table == 'PermissionRole') {
                     $extendedText = sprintf(
                         'Effective groups: %s, Effective permissions: %s',
-                        implode(array_values($data->Groups()->map('ID', 'Title')->toArray()), ', '),
-                        implode(array_values($data->Codes()->map('ID', 'Code')->toArray()), ', ')
+                        implode($data->Groups()->column('Title'), ', '),
+                        implode($data->Codes()->column('Code'), ', ')
                     );
                 }
                 if ($table == 'Member') {
                     $extendedText = sprintf(
                         'Effective groups: %s',
-                        implode(array_values($data->Groups()->map('ID', 'Title')->toArray()), ', ')
+                        implode($data->Groups()->column('Title'), ', ')
                     );
                 }
 
@@ -181,7 +181,7 @@ class AuditHook extends \SiteTreeExtension
 
         $effectiveViewerGroups = '';
         if ($this->owner->CanViewType == 'OnlyTheseUsers') {
-            $effectiveViewerGroups = implode(array_values($original->ViewerGroups()->map('ID', 'Title')->toArray()), ', ');
+            $effectiveViewerGroups = implode($original->ViewerGroups()->column('Title'), ', ');
         }
         if (!$effectiveViewerGroups) {
             $effectiveViewerGroups = $this->owner->CanViewType;


### PR DESCRIPTION
Framework 3 has a bug where it promises to return array from SS_List.
RelationList implements SS_List - wrongly, because it returns SS_Map
instead of an array. This confused the auditor author to treat the
HasMany return value as SS_Map which is incorrect, and breaks.

The problem results in an "ERROR [User Error]: Uncaught Error: Call to a
member function toArray() on array" when for example publishing a page
with CanViewType set to OnlyTheseUsers for the first time.

This breach of contract in RelationList/DataList has been fixed in SS4.