### PR TITLE
Fix logging of failed logins & unknown users

### DIFF
--- a/code/AuditHook.php
+++ b/code/AuditHook.php
@@ -382,7 +382,7 @@ class AuditHook extends DataExtension
         // LDAP authentication uses a "Login" POST field instead of Email.
         $login = isset($data['Login'])
             ? $data['Login']
-            : (isset($data[Email::class]) ? $data[Email::class] : '');
+            : (isset($data['Email']) ? $data['Email'] : '');
 
         if (empty($login)) {
             return $this->getAuditLogger()->warning(
@@ -392,6 +392,14 @@ class AuditHook extends DataExtension
         }
 
         $this->getAuditLogger()->info(sprintf('Failed login attempt using email "%s"', $login));
+    }
+
+    /**
+     * Log failed login attempts when the email address doesn't map to an existing member record
+     */
+    public function authenticationFailedUnknownUser($data)
+    {
+        $this->authenticationFailed($data);
     }
 
     /**

--- a/tests/AuditHookTest.php
+++ b/tests/AuditHookTest.php
@@ -333,4 +333,31 @@ class AuditHookTest extends FunctionalTest
         $this->assertStringContainsString('deleted Page', $message);
         $this->assertStringContainsString('My page', $message);
     }
+
+    public function testFailedLogin()
+    {
+        $member = $this->createMemberWithPermission('ADMIN');
+        $this->get('Security/login');
+        $this->submitForm(
+            'MemberLoginForm_LoginForm',
+            null,
+            ['Email' => $member->Email, 'Password' => 'clearly wrong password']
+        );
+
+        $message = $this->writer->getLastMessage();
+        $this->assertStringContainsString('Failed login attempt using email "' . $member->Email . '"', $message);
+    }
+
+    public function testFailedLoginWithoutMember()
+    {
+        $this->get('Security/login');
+        $this->submitForm(
+            'MemberLoginForm_LoginForm',
+            null,
+            ['Email' => '__NO VALID USER__', 'Password' => 'clearly wrong password']
+        );
+
+        $message = $this->writer->getLastMessage();
+        $this->assertStringContainsString('Failed login attempt using email "__NO VALID USER__"', $message);
+    }
 }


### PR DESCRIPTION
Fixes the `authenticationFailed()` method to correctly return the login email, and adds `authenticationFailedUnknownUser()` method to log unknown user login attempts.

## Issue
- https://github.com/silverstripe/silverstripe-auditor/issues/63