### PR TITLE
FIX Use correct namespace for session manager controller

### DIFF
--- a/_config/session-manager.yml
+++ b/_config/session-manager.yml
@@ -3,6 +3,6 @@ Name: auditor-session-manager
 Only:
   moduleexists: silverstripe/session-manager
 ---
-SilverStripe\SessionManager\Control\LoginSessionController:
+SilverStripe\SessionManager\Controllers\LoginSessionController:
   extensions:
     - SilverStripe\Auditor\AuditHookSessionManager

--- a/tests/AuditHookSessionManagerTest.php
+++ b/tests/AuditHookSessionManagerTest.php
@@ -10,7 +10,7 @@ use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
 use SilverStripe\Security\SecurityToken;
-use SilverStripe\SessionManager\Control\LoginSessionController;
+use SilverStripe\SessionManager\Controllers\LoginSessionController;
 use SilverStripe\SessionManager\Models\LoginSession;
 
 class AuditHookSessionManagerTest extends SapphireTest
@@ -38,27 +38,29 @@ class AuditHookSessionManagerTest extends SapphireTest
     {
         $this->logInWithPermission('ADMIN');
 
-        $currentUser = Security::getCurrentUser();
-
         $member = new Member(array('FirstName' => 'Joe', 'Email' => 'joe3'));
         $member->write();
         $request = Controller::curr()->getRequest();
         $loginSession = LoginSession::generate($member, false, $request);
 
+        // Only the current user is able to remove their login session, not even admin can do it
+        Security::setCurrentUser($member);
+
         SecurityToken::disable();
         $mockRequest = new HTTPRequest('DELETE', '');
         $mockRequest->setRouteParams(['ID' => $loginSession->ID]);
         $controller = new LoginSessionController();
-        $controller->removeLoginSession($mockRequest);
+        $controller->remove($mockRequest);
 
         $message = sprintf(
             'Login session (ID: %s) for Member "%s" (ID: %s) is being removed by Member "%s" (ID: %s)',
             $loginSession->ID,
             $member->Email,
             $member->ID,
-            $currentUser->Email,
-            $currentUser->ID
+            $member->Email,
+            $member->ID
         );
-        $this->assertContains($message, $this->writer->getLastMessage());
+
+        $this->assertStringContainsString($message, $this->writer->getLastMessage());
     }
 }


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-auditor/issues/55

The unit test hasn't run for a long time because the extension wasn't being attached. The unit test fails, because the logic has since been updated so sessions can only be removed by the user who the LoginSession belongs to