### PR TITLE
DEP Bump minimum version of framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": "^7.4 || ^8.0",
-        "silverstripe/framework": "^4.12",
+        "silverstripe/framework": "^4.13",
         "monolog/monolog": "~1.11",
         "psr/log": "~1.0",
         "tractorcow/silverstripe-proxy-db": "^1"


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/284

Failing on Deprecation::withNoReplacement() on --prefer-lowest build
https://github.com/silverstripe/silverstripe-auditor/actions/runs/9851667628